### PR TITLE
Add twitter module

### DIFF
--- a/boxbot/boxbot.py
+++ b/boxbot/boxbot.py
@@ -23,6 +23,7 @@ import yaml
 import rssfeed
 import urltitle
 import updatenotifier
+import twitter
 
 # todo: features:
 # * a fully fledged command parser
@@ -274,6 +275,7 @@ class BotFactory(protocol.ReconnectingClientFactory):
         self.rssConfig = config['rss']
         self.quakeConfig = config['quakeAuth']
         self.notifyConfig = config['notifyComics']
+        self.twitterConfig = config['twitter']
         # pass the config to feed monitor
         log.debug("bot factory initilized")
 
@@ -299,6 +301,10 @@ class BotFactory(protocol.ReconnectingClientFactory):
         # start the comic update notifier clock thingy, and provide it a bot too:
         log.debug("creating a comic update time notifier")
         self.comicNotifier = updatenotifier.Notifier(self.notifyConfig, p)
+
+        log.debug("creating a twitter feed listener")
+        self.tweetListener = twitter.IRCListener(self.twitterConfig, p)
+
         # reset reconnection delay
         self.resetDelay()
         return p

--- a/boxbot/twitter.py
+++ b/boxbot/twitter.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""
+twitter reader module
+
+Relays tweets to IRC
+"""
+
+# depends on tweepy; just do `pip install tweepy`
+
+import logging
+log = logging.getLogger(__name__)
+
+from tweepy.streaming import StreamListener
+from tweepy import OAuthHandler
+from tweepy import Stream
+
+import json
+
+class IRCListener(StreamListener):
+
+    def __init__(self, config, bot):
+        self.bot = bot
+
+        self.auth = OAuthHandler(config["auth"]["consumer_key"], config["auth"]["consumer_secret"])
+        self.auth.set_access_token(config["auth"]["access_token"], config["auth"]["access_token_secret"])
+
+        stream = Stream(self.auth, self)
+        stream.userstream(track=config["follow"], async=True)
+
+        log.debug("a twitter.IRCListener instance created")
+
+    def on_data(self, data):
+        parsed = json.loads(data)
+        if "text" in parsed:
+            self.bot.announce(parsed["user"]["name"] + " tweeted \"" + parsed["text"] + "\"")
+        return True
+
+    def on_error(self, status):
+        log.debug("Twitter error: " + status)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -16,6 +16,15 @@ nickname:  "yournick"
 realname:  "yourname"
 build:     "unstable dev build"
 
+twitter:
+        auth:
+            consumer_key:         twitterConsumerKey
+            consumer_secret:      twitterConsumerSecret
+            access_token:         twitterAccessToken
+            access_token_secret:  twitterAccessTokenSecret
+        follow:
+            - gunnerkrigg
+
 notifyComics:
         comics:
             Gunnerkrigg Court : {


### PR DESCRIPTION
This adds basic Twitter support to the bot. Supply a list of usernames to follow in the config file, and all of their tweets will be posted to the channel.

It requires OAuth tokens for Twitter; I'll send that to you privately. In addition, you'll need to install the `tweepy` python module.